### PR TITLE
Updated umbraco-marketplace.json to fix category name

### DIFF
--- a/umbraco-marketplace.json
+++ b/umbraco-marketplace.json
@@ -4,7 +4,7 @@
     "Url": "http://youritteam.com.au",
     "ImageUrl": "https://our.umbraco.com/media/upload/87499f6e-4497-4cb0-a2b6-bf03e222cfc0/220427_ROB_FIONA_0031.jpeg?width=250&height=250&mode=crop"
   },
-  "Category": "CMS Extensions",
+  "Category": "Editor Tools",
   "LicenseType": "Free",
   "PackageType": "Package",
   "PackagesByAuthor": ["OpenOrClosed"],


### PR DESCRIPTION
Hi @robertjf - I noticed your package wasn't being listed in a category on the Umbraco marketplace.  This update should fix that.  I think you probably got the one you had from some early example, but at launch the list of categories were updated.  You can find the full list [here](https://marketplace.umbraco.com/listing) if you think it's better to select something else.